### PR TITLE
Fix Child_Only defintion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
       r: release
     - os: linux
       r: devel
-    - os: osx
-      osx_image: xcode8
-      r: release
 r_packages:
   - covr
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ r_check_args: --no-manual --timings
 r:
   - release
   - devel
+os:
+  - linux
+  - osx
 r_packages:
   - covr
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ r_check_args: --no-manual --timings
 r:
   - release
   - devel
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+    - os: osx
+      osx_image: xcode8
 r_packages:
   - covr
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ r_check_args: --no-manual --timings
 matrix:
   include:
     - os: linux
-      r:
-        - release
-        - devel
+      r: release
+    - os: linux
+      r: devel
     - os: osx
       osx_image: xcode8
       r: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-
 language: r
 cache: packages
 sudo: false
 r_build_args: --no-build-vignettes
 r_check_args: --no-manual --timings
-r:
-  - release
-  - devel
 matrix:
   include:
     - os: linux
+      r:
+        - release
+        - devel
     - os: osx
       osx_image: xcode8
+      r: release
 r_packages:
   - covr
 after_success:

--- a/R/subprocess.R
+++ b/R/subprocess.R
@@ -215,5 +215,5 @@ TERMINATION_GROUP <- "group"
 #' 
 #' @rdname spawn_process
 #' @export
-TERMINATION_CHILD_ONLY <- "child-only"
+TERMINATION_CHILD_ONLY <- "child_only"
 

--- a/R/subprocess.R
+++ b/R/subprocess.R
@@ -77,6 +77,9 @@ spawn_process <- function (command, arguments = character(), environment = chara
     environment <- paste(names(environment), as.character(environment), sep = '=')
   }
   
+  if(!(is.null(workdir) || identical(workdir, ""))){
+    workdir <- normalizePath(workdir, mustWork = TRUE)
+  }
   # hand over to C
   handle <- .Call("C_process_spawn", command, c(command, as.character(arguments)),
                   as.character(environment), as.character(workdir),


### PR DESCRIPTION
1. Fix the R Side definition of TERMINATION_CHILD_ONLY to reconcile with how it is defined in the C code.
2. Normalize working directory argument and allow path expansion (e.g workdir = "~")