### PR TITLE
Clean-up R tmp directories in tests

### DIFF
--- a/tests/testthat/helper-processes.R
+++ b/tests/testthat/helper-processes.R
@@ -58,7 +58,7 @@ wait_until_appears <- function (handle)
     process_wait(handle, TIMEOUT_IMMEDIATE)
     if (process_state(handle) %in% c("exited", "terminated"))
       stop('failed to start ', handle$command, call. = FALSE)
-    Sys.sleep(1)
+    Sys.sleep(.1)
   }
   return(TRUE)
 }
@@ -67,8 +67,20 @@ wait_until_appears <- function (handle)
 wait_until_exits <- function (handle)
 {
   while (process_exists(handle)) {
-    Sys.sleep(1)
+    Sys.sleep(.1)
   }
   return(TRUE)
+}
+
+
+terminate_gracefully <- function (handle, message = "q('no')\n")
+{
+  if (!is.null(message)) {
+    process_write(handle, message)
+  }
+
+  process_close_input(handle)
+  process_wait(handle)
+  wait_until_exits(handle)
 }
 

--- a/tests/testthat/helper-processes.R
+++ b/tests/testthat/helper-processes.R
@@ -83,4 +83,3 @@ terminate_gracefully <- function (handle, message = "q('no')\n")
   process_wait(handle)
   wait_until_exits(handle)
 }
-

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -21,6 +21,9 @@ test_that("working directory can be set", {
   process_write(handle_2, print_wd)
   expect_equal(normalizePath(process_read(handle_2, timeout = 1000)$stdout),
                work_dir)
+  
+  terminate_gracefully(handle)
+  terminate_gracefully(handle_2)
 })
 
 
@@ -45,6 +48,8 @@ test_that("passing new environment", {
   
   process_write(handle, 'cat(Sys.getenv("VAR"))\n')
   expect_equal(process_read(handle, timeout = 1000)$stdout, 'SOME_VALUE')
+  
+  terminate_gracefully(handle)
 })
 
 
@@ -54,6 +59,8 @@ test_that("new environment via named vector", {
   
   process_write(handle, 'cat(Sys.getenv("VAR"))\n')
   expect_equal(process_read(handle, timeout = 1000)$stdout, 'SOME_VALUE')
+  
+  terminate_gracefully(handle)
 })
 
 
@@ -63,6 +70,8 @@ test_that("new environment via list", {
   
   process_write(handle, 'cat(Sys.getenv("VAR"))\n')
   expect_equal(process_read(handle, timeout = 1000)$stdout, 'SOME_VALUE')
+  
+  terminate_gracefully(handle)
 })
 
 

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -30,7 +30,7 @@ test_that("inherits environment from parent", {
   on.exit(Sys.unsetenv("PARENT_VAR"), add = TRUE)
   Sys.setenv(PARENT_VAR="PARENT_VAL")
   
-  on.exit(terminate_gracefully(handle), add = TRUE)
+  on.exit(process_terminate(handle), add = TRUE)
   handle <- R_child(c("--slave", "-e", "cat(Sys.getenv('PARENT_VAR'))"))
   
   expect_equal(process_read(handle, timeout = TIMEOUT_INFINITE)$stdout, 'PARENT_VAL')

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -8,22 +8,19 @@ test_that("working directory can be set", {
   norm_wd  <- normalizePath(getwd())
   expect_false(identical(work_dir, getwd()))
   
-  on.exit(process_terminate(handle), add = TRUE)
+  on.exit(terminate_gracefully(handle), add = TRUE)
   handle <- R_child()
   
   process_write(handle, print_wd)
   expect_equal(normalizePath(process_read(handle, timeout = 1000)$stdout),
                norm_wd)
   
-  on.exit(process_terminate(handle_2), add = TRUE)
+  on.exit(terminate_gracefully(handle_2), add = TRUE)
   handle_2 <- R_child(workdir = work_dir)
   
   process_write(handle_2, print_wd)
   expect_equal(normalizePath(process_read(handle_2, timeout = 1000)$stdout),
                work_dir)
-  
-  terminate_gracefully(handle)
-  terminate_gracefully(handle_2)
 })
 
 
@@ -33,7 +30,7 @@ test_that("inherits environment from parent", {
   on.exit(Sys.unsetenv("PARENT_VAR"), add = TRUE)
   Sys.setenv(PARENT_VAR="PARENT_VAL")
   
-  on.exit(process_terminate(handle), add = TRUE)
+  on.exit(terminate_gracefully(handle), add = TRUE)
   handle <- R_child(c("--slave", "-e", "cat(Sys.getenv('PARENT_VAR'))"))
   
   expect_equal(process_read(handle, timeout = TIMEOUT_INFINITE)$stdout, 'PARENT_VAL')
@@ -43,35 +40,29 @@ test_that("inherits environment from parent", {
 
 
 test_that("passing new environment", {
-  on.exit(process_terminate(handle), add = TRUE)
+  on.exit(terminate_gracefully(handle), add = TRUE)
   handle <- R_child(environment = "VAR=SOME_VALUE")
   
   process_write(handle, 'cat(Sys.getenv("VAR"))\n')
   expect_equal(process_read(handle, timeout = 1000)$stdout, 'SOME_VALUE')
-  
-  terminate_gracefully(handle)
 })
 
 
 test_that("new environment via named vector", {
-  on.exit(process_terminate(handle), add = TRUE)
+  on.exit(terminate_gracefully(handle), add = TRUE)
   handle <- R_child(environment = c(VAR="SOME_VALUE"))
   
   process_write(handle, 'cat(Sys.getenv("VAR"))\n')
   expect_equal(process_read(handle, timeout = 1000)$stdout, 'SOME_VALUE')
-  
-  terminate_gracefully(handle)
 })
 
 
 test_that("new environment via list", {
-  on.exit(process_terminate(handle), add = TRUE)
+  on.exit(terminate_gracefully(handle), add = TRUE)
   handle <- R_child(environment = list(VAR="SOME_VALUE"))
   
   process_write(handle, 'cat(Sys.getenv("VAR"))\n')
   expect_equal(process_read(handle, timeout = 1000)$stdout, 'SOME_VALUE')
-  
-  terminate_gracefully(handle)
 })
 
 

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -5,7 +5,7 @@ test_that("output buffer is flushed", {
   command <- paste0('cat(sep = "\\n", replicate(', lines,
                     ', paste(sample(letters, 60, TRUE), collapse = "")))')
 
-  on.exit(process_kill(handle))
+  on.exit(terminate_gracefully(handle))
   handle <- R_child()
   expect_true(process_exists(handle))
 
@@ -22,7 +22,7 @@ test_that("output buffer is flushed", {
 
 
 test_that("exchange data", {
-  on.exit(process_kill(handle))
+  on.exit(terminate_gracefully(handle))
   handle <- R_child()
   
   expect_true(process_exists(handle))
@@ -37,7 +37,7 @@ test_that("exchange data", {
 
 
 test_that("read from standard error output", {
-  on.exit(process_kill(handle))
+  on.exit(terminate_gracefully(handle))
   handle <- R_child()
   
   process_write(handle, 'cat("A", file = stderr())\n')
@@ -49,7 +49,7 @@ test_that("read from standard error output", {
 
 
 test_that("write returns the number of characters", {
-  on.exit(process_kill(handle))
+  on.exit(terminate_gracefully(handle))
   handle <- R_child()
   
   expect_equal(process_write(handle, 'cat("A")\n'), 9)
@@ -57,7 +57,7 @@ test_that("write returns the number of characters", {
 
 
 test_that("non-blocking read", {
-  on.exit(process_kill(handle))
+  on.exit(terminate_gracefully(handle))
   
   handle <- R_child()
   expect_true(process_exists(handle))
@@ -67,4 +67,3 @@ test_that("non-blocking read", {
   expect_equal(process_read(handle, PIPE_BOTH), list(stdout = character(0),
                                                      stderr = character(0)))
 })
-

--- a/tests/testthat/test-termination.R
+++ b/tests/testthat/test-termination.R
@@ -101,7 +101,7 @@ test_that("child process is terminated in Linux", {
 
 
 test_that("child exits when stdin is closed", {
-  on.exit(process_kill(handle))
+  on.exit(process_terminate(handle))
   handle <- R_child()
   expect_true(process_exists(handle))
 

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -12,11 +12,12 @@ test_that("multi-byte can come in parts", {
     process_write(handle, paste0("cat('", text, "')\n"))
   }
 
+  on.exit(terminate_gracefully(handle1))
   handle1 <- R_child()
+
   print_in_R(handle1, "a\\xF0\\x90")
   expect_equal(process_read(handle1, timeout = TIMEOUT_INFINITE)$stdout, 'a')
   
   print_in_R(handle1, "\\x8D\\x88b")
   expect_equal(process_read(handle1, timeout = TIMEOUT_INFINITE)$stdout, '\xF0\x90\x8D\x88b')
 })
-


### PR DESCRIPTION
* a number of test cases need additional clean-up calls to make sure all Rtmp* directories are removed after use