### PR TITLE
Fix Windows compilation

### DIFF
--- a/src/config-os.h
+++ b/src/config-os.h
@@ -16,6 +16,16 @@
 
 
 #ifdef SUBPROCESS_WINDOWS
+#define EXPORT __declspec( dllexport )
+#else
+#define EXPORT 
+#endif
+
+
+/* When included in rapi.h, OS API causes compilation errors. */
+#ifndef NO_SYSTEM_API
+
+#ifdef SUBPROCESS_WINDOWS
 
 /* MinGW defines this by default */
 #ifdef _WIN32_WINNT
@@ -49,7 +59,6 @@ typedef HANDLE pipe_handle_type;
 
 constexpr pipe_handle_type HANDLE_CLOSED = nullptr;
 
-
 #else /* !SUBPROCESS_WINDOWS */
 
 #include <unistd.h>
@@ -58,15 +67,8 @@ typedef int pipe_handle_type;
 
 constexpr pipe_handle_type HANDLE_CLOSED = -1;
 
-
 #endif /* SUBPROCESS_WINDOWS */
 
-
-#ifdef SUBPROCESS_WINDOWS
-#define EXPORT __declspec( dllexport )
-#else
-#define EXPORT 
-#endif
-
+#endif /* NO_SYSTEM_API */
 
 #endif /* CONFIG_WIN_H_GUARD */

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -4,7 +4,10 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 
+#define NO_SYSTEM_API
+#include "config-os.h"
 #include "rapi.h"
+
 
 static const R_CallMethodDef callMethods[]  = {
   { "C_process_spawn",        (DL_FUNC) &C_process_spawn,        5 },


### PR DESCRIPTION
exclude OS API when also using R internals