### PR TITLE
Various fixes

### DIFF
--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -82,7 +82,9 @@ static time_t clock_millisec ()
   clock_gettime(CLOCK_REALTIME, &current);
 #endif
 
-  return (int)current.tv_sec * 1000 + (int)(current.tv_nsec / 1000000);
+  long long current_time = static_cast<long long>(current.tv_sec) * 1000L +
+                           static_cast<long long>(current.tv_nsec / 1000000L);
+  return static_cast<time_t>(current_time);
 }
 
 

--- a/src/subprocess.cc
+++ b/src/subprocess.cc
@@ -59,7 +59,7 @@ size_t consume_utf8 (const char * _input, size_t _length)
 {
   wchar_t wc;
   size_t used, consumed = 0;
-  mbstate_t mb_st { 0 };
+  mbstate_t mb_st = { };
 
   if (!mbsinit(&mb_st)) memset(&mb_st,0,sizeof(mb_st));
 


### PR DESCRIPTION
* initialize the whole structure to zeros to silence valgrind
* cast time to `long long` to avoid overflow