### PR TITLE
Fix test case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: subprocess
 Type: Package
 Title: Manage Sub-Processes in R
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: person("Lukasz", "Bartnik", email = "l.bartnik@gmail.com", role = c("aut", "cre"))
 Description: Create and handle multiple sub-processes in R, exchange
   data over standard input and output streams, control their life cycle.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# subprocess 0.8.2
+
+* fixes in test cases for `testthat` 2.0
+
 # subprocess 0.8.1
 
 * explicitly register native symbols

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -11,9 +11,8 @@ test_that("onLoad is correct", {
 
   # intercept assignments
   assignMock <- mock(T, cycle = TRUE)
-  with_mock(`base::assign` = assignMock, {
-    dotOnLoad('libname', 'subprocess')
-  })
+  mockery::stub(dotOnLoad, 'assign', assignMock)
+  dotOnLoad('libname', 'subprocess')
 
   expect_called(assignMock, length(known))
 })


### PR DESCRIPTION
* `testthat` 2 comes with certain new limitations - `with_mock` cannot be used to mock functions in the `base` package