### PR TITLE
Use poll() instead of select()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * fixes building under Solaris
 
+* replace `select()` with `poll()`
+
 # subprocess 0.8.2
 
 * fixes in test cases for `testthat` 2.0

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -23,6 +23,7 @@
 
 
 #ifdef SUBPROCESS_MACOS
+// for some reason environ is unaccessible via unistd.h
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -259,7 +259,7 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
         _environment = environ;
       }
 
-      ::write(cntl_pipes[pipe_holder::WRITE], "S", 1);
+      rc = ::write(cntl_pipes[pipe_holder::WRITE], "S", 1);
       /* finally start the new process */
       execve(_command, _arguments, _environment);
 
@@ -268,7 +268,7 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
       perror((string("could not run command ") + _command).c_str());
     }
     catch (subprocess_exception & e) {
-      ::write(cntl_pipes[pipe_holder::WRITE], "F", 1);
+      rc = ::write(cntl_pipes[pipe_holder::WRITE], "F", 1);
       
       // we do not name stderr explicitly because CRAN doesn't like it
       ignore_return_value(::write(2, e.what(), strlen(e.what())));
@@ -413,10 +413,10 @@ ssize_t timed_read (process_handle_t & _handle, pipe_type _pipe, int _timeout)
     return 0;
   }
 
-  if (fds[0].fd != -1 && && fds[0].revents == POLLIN) { 
+  if (fds[0].fd != -1 && fds[0].revents == POLLIN) { 
     rc = std::min(rc, (ssize_t)_handle.stdout_.read(_handle.pipe_stdout, mbcslocale));
   }
-  if (fds[1].fd != -1 && && fds[1].revents == POLLIN) {
+  if (fds[1].fd != -1 && fds[1].revents == POLLIN) {
     rc = std::min(rc, (ssize_t)_handle.stderr_.read(_handle.pipe_stderr, mbcslocale));
   }
   

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -13,6 +13,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/poll.h>
 #include <dlfcn.h>
 
 #include <fcntl.h>              /* Obtain O_* constant definitions */
@@ -23,7 +24,6 @@
 
 
 #ifdef SUBPROCESS_MACOS
-// for some reason environ is unaccessible via unistd.h
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -216,6 +216,9 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
     throw subprocess_exception(EALREADY, "process already started");
   }
 
+  int rc, cntl_pipes[2];
+  rc = pipe(cntl_pipes);
+
   // can be addressed with PIPE_STDIN, PIPE_STDOUT, PIPE_STDERR
   pipe_holder pipes[3];
 
@@ -228,6 +231,8 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
    * ends of pipes */
   if (child_id == 0) {
     try {
+      rc = ::close(cntl_pipes[0]); // close unused read end
+
       dup2(pipes[PIPE_STDIN][pipe_holder::READ], STDIN_FILENO);
       dup2(pipes[PIPE_STDOUT][pipe_holder::WRITE], STDOUT_FILENO);
       dup2(pipes[PIPE_STDERR][pipe_holder::WRITE], STDERR_FILENO);
@@ -246,7 +251,7 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
 
       /* if termination mode is "group" start new session */
       if (_termination_mode == TERMINATION_GROUP) {
-        setsid();
+	setsid();
       }
       
       /* if environment is empty, use parent's environment */
@@ -254,6 +259,8 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
         _environment = environ;
       }
 
+      rc = ::write(cntl_pipes[1], "S", 1);
+      rc = ::close(cntl_pipes[1]);
       /* finally start the new process */
       execve(_command, _arguments, _environment);
 
@@ -262,10 +269,15 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
       perror((string("could not run command ") + _command).c_str());
     }
     catch (subprocess_exception & e) {
+      rc = ::write(cntl_pipes[1], "F", 1);
+      rc = ::close(cntl_pipes[1]);
+
       // we do not name stderr explicitly because CRAN doesn't like it
       ignore_return_value(::write(2, e.what(), strlen(e.what())));
       exit_on_failure();
     }
+  } else {
+    rc = ::close(cntl_pipes[1]); // close unused write end
   }
 
   // child is now running
@@ -285,6 +297,11 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
   pipes[PIPE_STDIN][pipe_holder::WRITE] = HANDLE_CLOSED;
   pipes[PIPE_STDOUT][pipe_holder::READ] = HANDLE_CLOSED;
   pipes[PIPE_STDERR][pipe_holder::READ] = HANDLE_CLOSED;
+
+ char buf = 0;
+ rc = ::read(cntl_pipes[0], &buf, 1);
+ rc = ::close(cntl_pipes[0]); 
+ wait(TIMEOUT_IMMEDIATE);
 }
 
 
@@ -354,31 +371,22 @@ struct enable_block_mode {
 };
 
 
-struct select_reader {
-  
-  fd_set set;
-  int max_fd;
-  
-  select_reader () : max_fd(0) { }
-  
-  void put_fd (int _fd) {
-    FD_SET(_fd, &set);
-    max_fd = std::max(max_fd, _fd);
-  }
-  
   ssize_t timed_read (process_handle_t & _handle, pipe_type _pipe, int _timeout)
   {
     // this should never be called with "infinite" timeout
     if (_timeout < 0)
       return -1;
-    
-    FD_ZERO(&set);
+    struct pollfd fds[2];
+    memset(fds, 0, sizeof(fds));
+
     if (_pipe & PIPE_STDOUT) {
-      put_fd(_handle.pipe_stdout);
+	fds[0].fd = _handle.pipe_stdout;
+	fds[0].events = POLLIN;
       _handle.stdout_.clear();
     }
     if (_pipe & PIPE_STDERR) {
-      put_fd(_handle.pipe_stderr);
+	fds[1].fd = _handle.pipe_stderr;
+	fds[1].events = POLLIN;
       _handle.stderr_.clear();
     }
     
@@ -387,35 +395,27 @@ struct select_reader {
     ssize_t rc;
 
     do {
-      timediff = _timeout - (clock_millisec() - start);
-
       // use max so that _timeout can be TIMEOUT_IMMEDIATE and yet
-      // select can be tried at least once
-      timeout.tv_sec = std::max(0, timediff/1000);
-      timeout.tv_usec = std::max(0, (timediff % 1000) * 1000);
-      
-      rc = select(max_fd + 1, &set, NULL, NULL, &timeout);
-      if (rc == -1 && errno != EINTR && errno != EAGAIN)
-        return -1;
-      
+      // pool can be tried at least once
+      timediff = std::max(0L, _timeout - (clock_millisec() - start));
+
+      rc = poll(fds, 2, timediff);
     } while(rc == 0 && timediff > 0);
     
     // nothing to read; if errno == EINTR try reading one last time
-    if (rc == 0 || errno == EAGAIN)
+    if (rc == 0) { // timedout || errno == EAGAIN) {
       return 0;
-    
-    if (FD_ISSET(_handle.pipe_stdout, &set)) {
+    }
+ 
+    if ((_pipe & PIPE_STDOUT) && fds[0].revents == POLLIN) { 
       rc = std::min(rc, (ssize_t)_handle.stdout_.read(_handle.pipe_stdout, mbcslocale));
     }
-    if (FD_ISSET(_handle.pipe_stderr, &set)) {
+    if ((_pipe & PIPE_STDERR) && fds[1].revents == POLLIN) {
       rc = std::min(rc, (ssize_t)_handle.stderr_.read(_handle.pipe_stderr, mbcslocale));
     }
     
     return rc;
   }
-};
-
-
 
 
 size_t process_handle_t::read (pipe_type _pipe, int _timeout)
@@ -425,17 +425,16 @@ size_t process_handle_t::read (pipe_type _pipe, int _timeout)
   }
 
   ssize_t rc;
-  select_reader reader;
 
   // infinite timeout
   if (_timeout == TIMEOUT_INFINITE) {
     enable_block_mode blocker_out(pipe_stdout);
     enable_block_mode blocker_err(pipe_stderr);
-    rc = reader.timed_read(*this, _pipe, 1000);
+    rc = timed_read(*this, _pipe, 1000);
   }
   // finite or no timeout
   else {
-    rc = reader.timed_read(*this, _pipe, _timeout);
+    rc = timed_read(*this, _pipe, _timeout);
 
     if (rc < 0 && errno == EAGAIN) {
       /* stdin pipe is opened with O_NONBLOCK, so this means "would block" */
@@ -443,7 +442,6 @@ size_t process_handle_t::read (pipe_type _pipe, int _timeout)
       return 0;
     }
   }
-
   if (rc < 0) {
     throw subprocess_exception(errno, "could not read from child process");
   }
@@ -473,9 +471,8 @@ void process_handle_t::wait (int _timeout)
   if (!child_id) {
     throw subprocess_exception(ECHILD, "child does not exist");
   }
-  if (state != RUNNING) {
-    return;
-  }
+  if (state != RUNNING) 
+     return;
 
   /* to wait or not to wait? */ 
   int options = 0;
@@ -496,7 +493,8 @@ void process_handle_t::wait (int _timeout)
   } while (rc == 0 && _timeout > 0);
 
   // the child is still running
-  if (rc == 0) return;
+  if (rc == 0) 
+     return;
 
   // the child has exited or has been terminated
   if (WIFEXITED(return_code)) {
@@ -521,7 +519,6 @@ void process_handle_t::send_signal(int _signal)
   if (!child_id) {
     throw subprocess_exception(ECHILD, "child does not exist");
   }
-
   int rc = ::kill(child_id, _signal);
 
   if (rc < 0) {

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -476,8 +476,9 @@ void process_handle_t::wait (int _timeout)
   if (!child_id) {
     throw subprocess_exception(ECHILD, "child does not exist");
   }
-  if (state != RUNNING) 
+  if (state != RUNNING) {
      return;
+  }
 
   /* to wait or not to wait? */ 
   int options = 0;
@@ -498,8 +499,9 @@ void process_handle_t::wait (int _timeout)
   } while (rc == 0 && _timeout > 0);
 
   // the child is still running
-  if (rc == 0) 
+  if (rc == 0) {
      return;
+  }
 
   // the child has exited or has been terminated
   if (WIFEXITED(return_code)) {

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -391,6 +391,7 @@ ssize_t timed_read (process_handle_t & _handle, pipe_type _pipe, int _timeout)
     return 0;
   }
 
+  // TODO if an error occurs in the first read() it will be lost
   if (fds[0].fd != -1 && fds[0].revents == POLLIN) {
     rc = std::min(rc, (ssize_t)_handle.stdout_.read(_handle.pipe_stdout, mbcslocale));
   }
@@ -440,7 +441,7 @@ void process_handle_t::wait (int _timeout)
     throw subprocess_exception(ECHILD, "child does not exist");
   }
   if (state != RUNNING) {
-     return;
+    return;
   }
 
   /* to wait or not to wait? */

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -32,7 +32,6 @@
  * this is redundant in non-Solaris builds but fixes Solaris */
 extern char ** environ;
 
-
 #ifdef TRUE
 #undef TRUE
 #endif

--- a/src/sub-linux.cc
+++ b/src/sub-linux.cc
@@ -216,9 +216,9 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
     throw subprocess_exception(EALREADY, "process already started");
   }
 
-  int rc, cntl_pipes[2];
-  rc = pipe(cntl_pipes);
-
+  int rc = 0;
+  // this one is used to make parent know that subprocess started
+  pipe_holder cntl_pipes;
   // can be addressed with PIPE_STDIN, PIPE_STDOUT, PIPE_STDERR
   pipe_holder pipes[3];
 
@@ -231,7 +231,7 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
    * ends of pipes */
   if (child_id == 0) {
     try {
-      rc = ::close(cntl_pipes[0]); // close unused read end
+      close(cntl_pipes[pipe_holder::READ]);
 
       dup2(pipes[PIPE_STDIN][pipe_holder::READ], STDIN_FILENO);
       dup2(pipes[PIPE_STDOUT][pipe_holder::WRITE], STDOUT_FILENO);
@@ -251,7 +251,7 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
 
       /* if termination mode is "group" start new session */
       if (_termination_mode == TERMINATION_GROUP) {
-	setsid();
+        setsid();
       }
       
       /* if environment is empty, use parent's environment */
@@ -259,8 +259,7 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
         _environment = environ;
       }
 
-      rc = ::write(cntl_pipes[1], "S", 1);
-      rc = ::close(cntl_pipes[1]);
+      ::write(cntl_pipes[pipe_holder::WRITE], "S", 1);
       /* finally start the new process */
       execve(_command, _arguments, _environment);
 
@@ -269,15 +268,14 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
       perror((string("could not run command ") + _command).c_str());
     }
     catch (subprocess_exception & e) {
-      rc = ::write(cntl_pipes[1], "F", 1);
-      rc = ::close(cntl_pipes[1]);
-
+      ::write(cntl_pipes[pipe_holder::WRITE], "F", 1);
+      
       // we do not name stderr explicitly because CRAN doesn't like it
       ignore_return_value(::write(2, e.what(), strlen(e.what())));
       exit_on_failure();
     }
   } else {
-    rc = ::close(cntl_pipes[1]); // close unused write end
+    close(cntl_pipes[pipe_holder::WRITE]);
   }
 
   // child is now running
@@ -298,10 +296,11 @@ void process_handle_t::spawn (const char * _command, char *const _arguments[],
   pipes[PIPE_STDOUT][pipe_holder::READ] = HANDLE_CLOSED;
   pipes[PIPE_STDERR][pipe_holder::READ] = HANDLE_CLOSED;
 
- char buf = 0;
- rc = ::read(cntl_pipes[0], &buf, 1);
- rc = ::close(cntl_pipes[0]); 
- wait(TIMEOUT_IMMEDIATE);
+  { // wait for subprocess to start
+    char buf = 0;
+    rc = ::read(cntl_pipes[pipe_holder::READ], &buf, 1);    
+  }
+  wait(TIMEOUT_IMMEDIATE); // update process state
 }
 
 
@@ -371,51 +370,58 @@ struct enable_block_mode {
 };
 
 
-  ssize_t timed_read (process_handle_t & _handle, pipe_type _pipe, int _timeout)
-  {
-    // this should never be called with "infinite" timeout
-    if (_timeout < 0)
-      return -1;
-    struct pollfd fds[2];
-    memset(fds, 0, sizeof(fds));
+ssize_t timed_read (process_handle_t & _handle, pipe_type _pipe, int _timeout)
+{
+  // this should never be called with "infinite" timeout
+  if (_timeout < 0)
+    return -1;
+  
+  struct pollfd fds[2];
+  memset(fds, 0, sizeof(fds));
 
-    if (_pipe & PIPE_STDOUT) {
-	fds[0].fd = _handle.pipe_stdout;
-	fds[0].events = POLLIN;
-      _handle.stdout_.clear();
-    }
-    if (_pipe & PIPE_STDERR) {
-	fds[1].fd = _handle.pipe_stderr;
-	fds[1].events = POLLIN;
-      _handle.stderr_.clear();
-    }
-    
-    struct timeval timeout;
-    int start = clock_millisec(), timediff;
-    ssize_t rc;
-
-    do {
-      // use max so that _timeout can be TIMEOUT_IMMEDIATE and yet
-      // pool can be tried at least once
-      timediff = std::max(0L, _timeout - (clock_millisec() - start));
-
-      rc = poll(fds, 2, timediff);
-    } while(rc == 0 && timediff > 0);
-    
-    // nothing to read; if errno == EINTR try reading one last time
-    if (rc == 0) { // timedout || errno == EAGAIN) {
-      return 0;
-    }
- 
-    if ((_pipe & PIPE_STDOUT) && fds[0].revents == POLLIN) { 
-      rc = std::min(rc, (ssize_t)_handle.stdout_.read(_handle.pipe_stdout, mbcslocale));
-    }
-    if ((_pipe & PIPE_STDERR) && fds[1].revents == POLLIN) {
-      rc = std::min(rc, (ssize_t)_handle.stderr_.read(_handle.pipe_stderr, mbcslocale));
-    }
-    
-    return rc;
+  if (_pipe & PIPE_STDOUT) {
+    fds[0].fd = _handle.pipe_stdout;
+    fds[0].events = POLLIN;
+    _handle.stdout_.clear();
+  } 
+  else {
+    fds[0].fd = -1;
   }
+  
+  if (_pipe & PIPE_STDERR) {
+    fds[1].fd = _handle.pipe_stderr;
+    fds[1].events = POLLIN;
+    _handle.stderr_.clear();
+  } 
+  else {
+    fds[1].fd = -1;
+  }
+  
+  time_t start = clock_millisec(), timediff;
+  ssize_t rc;
+
+  do {
+    // use max so that _timeout can be TIMEOUT_IMMEDIATE and yet
+    // pool can be tried at least once
+    timediff = std::max((time_t)0, _timeout - (clock_millisec() - start));
+
+    rc = poll(fds, 2, timediff);
+  } while(rc == 0 && timediff > 0);
+  
+  // nothing to read; if errno == EINTR try reading one last time
+  if (rc == 0) { 
+    return 0;
+  }
+
+  if (fds[0].fd != -1 && && fds[0].revents == POLLIN) { 
+    rc = std::min(rc, (ssize_t)_handle.stdout_.read(_handle.pipe_stdout, mbcslocale));
+  }
+  if (fds[1].fd != -1 && && fds[1].revents == POLLIN) {
+    rc = std::min(rc, (ssize_t)_handle.stderr_.read(_handle.pipe_stderr, mbcslocale));
+  }
+  
+  return rc;
+}
 
 
 size_t process_handle_t::read (pipe_type _pipe, int _timeout)

--- a/subprocess.Rproj
+++ b/subprocess.Rproj
@@ -12,6 +12,9 @@ Encoding: UTF-8
 RnwWeave: knitr
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source --debug

--- a/tests/testthat/helper-processes.R
+++ b/tests/testthat/helper-processes.R
@@ -7,6 +7,10 @@ is_mac <- function ()
   identical(tolower(Sys.info()[["sysname"]]), 'darwin')
 }
 
+is_solaris <- function()
+{
+  identical(tolower(Sys.info()[["sysname"]]), 'sunos')
+}
 
 # --- R child ----------------------------------------------------------
 
@@ -37,8 +41,9 @@ process_exists <- function (handle)
     return(length(grep(pid, output, fixed = TRUE)) > 0)
   }
   else {
-    flag <- ifelse(is_mac(), "-p", "--pid")
-    rc <- system2("ps", c(flag, pid), stdout = NULL, stderr = NULL)
+    flag <- ifelse(is_mac() | is_solaris(), "-p", "--pid")
+    rc <- system2("ps", c(flag, as.character(pid)), stdout = NULL, 
+                  stderr = NULL)
     return(rc == 0)
   }
 }

--- a/tests/testthat/helper-processes.R
+++ b/tests/testthat/helper-processes.R
@@ -41,9 +41,8 @@ process_exists <- function (handle)
     return(length(grep(pid, output, fixed = TRUE)) > 0)
   }
   else {
-    flag <- ifelse(is_mac() | is_solaris(), "-p", "--pid")
-    rc <- system2("ps", c(flag, as.character(pid)), stdout = NULL, 
-                  stderr = NULL)
+    flag <- ifelse(is_mac() || is_solaris(), "-p", "--pid")
+    rc <- system2("ps", c(flag, pid), stdout = NULL, stderr = NULL)
     return(rc == 0)
   }
 }

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -14,7 +14,7 @@ test_that("output buffer is flushed", {
   Sys.sleep(3)
   
   # read everything
-  output <- process_read(handle, PIPE_STDOUT, TIMEOUT_INFINITE, flush = TRUE)
+  output <- process_read(handle, PIPE_STDOUT, 3000, flush = TRUE)
 
   expect_length(output, lines)
   expect_true(all(nchar(output) == 60))
@@ -31,8 +31,8 @@ test_that("exchange data", {
   output <- process_read(handle, timeout = 1000)
 
   expect_named(output, c('stdout', 'stderr'))
-  expect_equal(output$stdout, 'A')
   expect_equal(output$stderr, character())
+  expect_equal(output$stdout, 'A')
 })
 
 

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -14,7 +14,7 @@ test_that("output buffer is flushed", {
   Sys.sleep(3)
   
   # read everything
-  output <- process_read(handle, PIPE_STDOUT, 3000, flush = TRUE)
+  output <- process_read(handle, PIPE_STDOUT, TIMEOUT_INFINITE, flush = TRUE)
 
   expect_length(output, lines)
   expect_true(all(nchar(output) == 60))
@@ -31,8 +31,8 @@ test_that("exchange data", {
   output <- process_read(handle, timeout = 1000)
 
   expect_named(output, c('stdout', 'stderr'))
-  expect_equal(output$stderr, character())
   expect_equal(output$stdout, 'A')
+  expect_equal(output$stderr, character())
 })
 
 

--- a/tests/testthat/test-signals.R
+++ b/tests/testthat/test-signals.R
@@ -13,13 +13,10 @@ test_that("sending signal in Linux/MacOS/Solaris", {
   handle <- spawn_process(bash_path, c("-e", script_path))
   expect_true(process_exists(handle))
   
-  # excluded signals kill or stop the child
-  skip_sigs <- c(SIGHUP, SIGKILL, SIGCHLD, SIGSTOP)
-  if (is_solaris()) {
-    # on Solaris SIGQUIT behaviour is diffrent 
-    skip_sigs <- c(skip_sigs, SIGQUIT) 
-  }
-  for (signal in setdiff(signals, skip_sigs)) {
+  # exclude signals to kill or stop the child
+  skip <- c(SIGHUP, SIGKILL, SIGCHLD, SIGSTOP, if (is_solaris()) SIGQUIT) 
+
+  for (signal in setdiff(signals, skip)) {
     process_send_signal(handle, signal)
     output <- process_read(handle, PIPE_STDOUT, TIMEOUT_INFINITE)
     i <- which(signals == signal)
@@ -57,3 +54,4 @@ test_that("sending signal in Windows", {
   expect_equal(process_wait(handle, TIMEOUT_INFINITE), 1)
   expect_false(process_exists(handle))
 })
+

--- a/tests/testthat/test-signals.R
+++ b/tests/testthat/test-signals.R
@@ -1,8 +1,8 @@
 context("signals")
 
 
-test_that("sending signal in Linux", {
-  skip_if_not(is_linux())
+test_that("sending signal in Linux/MacOS", {
+  skip_if_not(is_linux() || is_mac())
 
   script_path <- file.path(getwd(), 'signal-trap.sh')
   expect_true(file.exists(script_path))

--- a/tests/testthat/test-signals.R
+++ b/tests/testthat/test-signals.R
@@ -1,8 +1,8 @@
 context("signals")
 
 
-test_that("sending signal in Linux/MacOS", {
-  skip_if_not(is_linux() || is_mac())
+test_that("sending signal in Linux/MacOS/Solaris", {
+  skip_if_not(is_linux() || is_mac() || is_solaris())
 
   script_path <- file.path(getwd(), 'signal-trap.sh')
   expect_true(file.exists(script_path))
@@ -14,11 +14,16 @@ test_that("sending signal in Linux/MacOS", {
   expect_true(process_exists(handle))
   
   # excluded signals kill or stop the child
-  for (signal in setdiff(signals, c(SIGHUP, SIGKILL, SIGCHLD, SIGSTOP))) {
+  skip_sigs <- c(SIGHUP, SIGKILL, SIGCHLD, SIGSTOP)
+  if (is_solaris()) {
+    # on Solaris SIGQUIT behaviour is diffrent 
+    skip_sigs <- c(skip_sigs, SIGQUIT) 
+  }
+  for (signal in setdiff(signals, skip_sigs)) {
     process_send_signal(handle, signal)
     output <- process_read(handle, PIPE_STDOUT, TIMEOUT_INFINITE)
     i <- which(signals == signal)
-    expect_equal(output, names(signals)[[i]])
+    expect_equal(output, names(signals)[[i]], info = names(signals)[[i]])
   }
 })
 

--- a/tests/testthat/test-signals.R
+++ b/tests/testthat/test-signals.R
@@ -6,7 +6,7 @@ test_that("sending signal in Linux", {
 
   script_path <- file.path(getwd(), 'signal-trap.sh')
   expect_true(file.exists(script_path))
-  
+
   bash_path <- "/bin/bash"
   expect_true(file.exists(bash_path))
   
@@ -14,10 +14,9 @@ test_that("sending signal in Linux", {
   expect_true(process_exists(handle))
   
   # excluded signals kill or stop the child
-  for (signal in setdiff(signals, c(1, 9, 17, 19))) {
+  for (signal in setdiff(signals, c(SIGHUP, SIGKILL, SIGCHLD, SIGSTOP))) {
     process_send_signal(handle, signal)
     output <- process_read(handle, PIPE_STDOUT, TIMEOUT_INFINITE)
-
     i <- which(signals == signal)
     expect_equal(output, names(signals)[[i]])
   }

--- a/tests/testthat/test-termination.R
+++ b/tests/testthat/test-termination.R
@@ -52,8 +52,8 @@ test_that("child process is terminated in Windows", {
 #
 # This test will, however, fail in plain R if termination_mode is
 # set to "child_only".
-test_that("child process is terminated in Linux", {
-  skip_if_not(is_linux())
+test_that("child process is terminated in Linux/MacOS", {
+  skip_if_not(is_linux() || is_mac())
 
   # the parent shell script will start "sleep" and print its PID
   shell <- Sys.getenv("SHELL", '/bin/sh')

--- a/tests/testthat/test-termination.R
+++ b/tests/testthat/test-termination.R
@@ -52,8 +52,8 @@ test_that("child process is terminated in Windows", {
 #
 # This test will, however, fail in plain R if termination_mode is
 # set to "child_only".
-test_that("child process is terminated in Linux/MacOS", {
-  skip_if_not(is_linux() || is_mac())
+test_that("child process is terminated in Linux/MacOS/SunOS", {
+  skip_if_not(is_linux() || is_mac() || is_solaris())
 
   # the parent shell script will start "sleep" and print its PID
   shell <- Sys.getenv("SHELL", '/bin/sh')

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -6,7 +6,7 @@ test_that("C tests pass", {
 
 
 test_that("multi-byte can come in parts", {
-  skip_if_not(is_linux() || is_mac())
+  skip_if_not(is_linux() || is_mac() || is_solaris())
   skip_if_not(l10n_info()$MBCS)
 
   print_in_R <- function (handle, text) {

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -17,8 +17,8 @@ test_that("multi-byte can come in parts", {
   handle1 <- R_child()
 
   print_in_R(handle1, "a\\xF0\\x90")
-  expect_equal(process_read(handle1, timeout = 1000, flush = TRUE)$stdout, 'a')
+  expect_equal(process_read(handle1, timeout = TIMEOUT_INFINITE)$stdout, 'a')
   
   print_in_R(handle1, "\\x8D\\x88b")
-  expect_equal(process_read(handle1, timeout = 100, flush = TRUE)$stdout, '\xF0\x90\x8D\x88b')
+  expect_equal(process_read(handle1, timeout = TIMEOUT_INFINITE)$stdout, '\xF0\x90\x8D\x88b')
 })

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -7,6 +7,7 @@ test_that("C tests pass", {
 
 test_that("multi-byte can come in parts", {
   skip_if_not(is_linux() || is_mac())
+  skip_if_not(l10n_info()$MBCS)
 
   print_in_R <- function (handle, text) {
     process_write(handle, paste0("cat('", text, "')\n"))

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -17,8 +17,8 @@ test_that("multi-byte can come in parts", {
   handle1 <- R_child()
 
   print_in_R(handle1, "a\\xF0\\x90")
-  expect_equal(process_read(handle1, timeout = TIMEOUT_INFINITE)$stdout, 'a')
+  expect_equal(process_read(handle1, timeout = 1000, flush = TRUE)$stdout, 'a')
   
   print_in_R(handle1, "\\x8D\\x88b")
-  expect_equal(process_read(handle1, timeout = TIMEOUT_INFINITE)$stdout, '\xF0\x90\x8D\x88b')
+  expect_equal(process_read(handle1, timeout = 100, flush = TRUE)$stdout, '\xF0\x90\x8D\x88b')
 })


### PR DESCRIPTION
* on *nix systems use `poll()` instead of `select()`; select has limitation on FD value to 1024
* test-utf8 is skipped if R does not support mbcs
* add control pipe to verify that the subprocess has already reached called `execve()`